### PR TITLE
feat: re-introduce docs package

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,59 +1,59 @@
 repository:
-    # See https://developer.github.com/v3/repos/#edit for all available settings.
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
 
-    # The name of the repository. Changing this will rename the repository
-    name: nixos-facter-docs
+  # The name of the repository. Changing this will rename the repository
+  name: nixos-facter-docs
 
-    # A short description of the repository that will show up on GitHub
-    description: Documentation for NixOS Facter and NixOS Facter Modules
+  # A short description of the repository that will show up on GitHub
+  description: Documentation for NixOS Facter and NixOS Facter Modules
 
-    #    # A URL with more information about the repository
-    #    homepage: "https://tbd.com"
+  #    # A URL with more information about the repository
+  #    homepage: "https://tbd.com"
 
-    # A comma-separated list of topics to set on the repository
-    topics: "nix, nixos, buildbot-numtide"
+  # A comma-separated list of topics to set on the repository
+  topics: "nix, nixos, buildbot-numtide"
 
-    # Either `true` to make the repository private, or `false` to make it public.
-    private: false
+  # Either `true` to make the repository private, or `false` to make it public.
+  private: false
 
-    # Either `true` to enable issues for this repository, `false` to disable them.
-    has_issues: true
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  has_issues: true
 
-    # Either `true` to enable projects for this repository, or `false` to disable them.
-    # If projects are disabled for the organization, passing `true` will cause an API error.
-    has_projects: false
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  has_projects: false
 
-    # Either `true` to enable the wiki for this repository, `false` to disable it.
-    has_wiki: false
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  has_wiki: false
 
-    # Either `true` to enable downloads for this repository, `false` to disable them.
-    has_downloads: false
+  # Either `true` to enable downloads for this repository, `false` to disable them.
+  has_downloads: false
 
-    # Updates the default branch for this repository.
-    default_branch: main
+  # Updates the default branch for this repository.
+  default_branch: main
 
-    # Either `true` to allow squash-merging pull requests, or `false` to prevent
-    # squash-merging.
-    allow_squash_merge: true
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
 
-    # Either `true` to allow merging pull requests with a merge commit, or `false`
-    # to prevent merging pull requests with merge commits.
-    allow_merge_commit: true
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: true
 
-    # Either `true` to allow rebase-merging pull requests, or `false` to prevent
-    # rebase-merging.
-    allow_rebase_merge: true
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: true
 
-    # Either `true` to enable automatic deletion of branches on merge, or `false` to disable
-    delete_branch_on_merge: true
+  # Either `true` to enable automatic deletion of branches on merge, or `false` to disable
+  delete_branch_on_merge: true
 
-    # Either `true` to enable automated security fixes, or `false` to disable
-    # automated security fixes.
-    enable_automated_security_fixes: true
+  # Either `true` to enable automated security fixes, or `false` to disable
+  # automated security fixes.
+  enable_automated_security_fixes: true
 
-    # Either `true` to enable vulnerability alerts, or `false` to disable
-    # vulnerability alerts.
-    enable_vulnerability_alerts: true
+  # Either `true` to enable vulnerability alerts, or `false` to disable
+  # vulnerability alerts.
+  enable_vulnerability_alerts: true
 
 # Labels: define labels for Issues and Pull Requests
 #
@@ -70,55 +70,55 @@ milestones:
 # Collaborators: give specific users access to this repository.
 # See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
 collaborators:
-    - username: brianmcgee
-      permission: admin
-    - username: zimbatm
-      permission: admin
-    - username: mic92
-      permission: admin
-    - username: osslate
-      permission: maintain
+  - username: brianmcgee
+    permission: admin
+  - username: zimbatm
+    permission: admin
+  - username: mic92
+    permission: admin
+  - username: osslate
+    permission: maintain
 
 # See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:
-    - name: network
-      # The permission to grant the team. Can be one of:
-      # * `pull` - can pull, but not push to or administer this repository.
-      # * `push` - can pull and push, but not administer this repository.
-      # * `admin` - can pull, push and administer this repository.
-      # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
-      # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
-      permission: maintain
+  - name: network
+    # The permission to grant the team. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+    # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+    # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
+    permission: maintain
 
 branches:
-    - name: main
-      # https://docs.github.com/en/rest/reference/repos#update-branch-protection
-      # Branch Protection settings. Set to null to disable
-      protection:
-          # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
-          required_pull_request_reviews:
-              # # The number of approvals required. (1-6)
-              required_approving_review_count: 1
-              # # Dismiss approved reviews automatically when a new commit is pushed.
-              dismiss_stale_reviews: true
-              # # Blocks merge until code owners have reviewed.
-              # require_code_owner_reviews: true
-              # # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
-              # dismissal_restrictions:
-              #   users: []
-              #   teams: []
-          # Required. Require status checks to pass before merging. Set to null to disable
-          required_status_checks:
-              # Required. Require branches to be up to date before merging.
-              strict: true
-              # Required. The list of status checks to require in order to merge into this branch
-              contexts: []
-          # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-          enforce_admins: false
-          # Disabled for mergify to work
-          required_linear_history: false
-          # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
-          restrictions:
-              apps: ["mergify"]
-              users: []
-              teams: []
+  - name: main
+    # https://docs.github.com/en/rest/reference/repos#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews:
+        # # The number of approvals required. (1-6)
+        required_approving_review_count: 1
+        # # Dismiss approved reviews automatically when a new commit is pushed.
+        dismiss_stale_reviews: true
+        # # Blocks merge until code owners have reviewed.
+        # require_code_owner_reviews: true
+        # # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+        # dismissal_restrictions:
+        #   users: []
+        #   teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: false
+      # Disabled for mergify to work
+      required_linear_history: false
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+      restrictions:
+        apps: ["mergify"]
+        users: []
+        teams: []

--- a/devshell.nix
+++ b/devshell.nix
@@ -1,5 +1,12 @@
-{ pkgs, ... }:
+{ pkgs, perSystem, ... }:
 pkgs.mkShellNoCC {
+  shellHook = ''
+    # mkdocs-mermaid2-plugin tries to download mermaidjs at runtime
+    # instead we packaged up mermaid in this flake and we symlink it in
+    # mkdocs.yml is configured to look for it there instead
+    ln -sf ${perSystem.self.mermaid} docs/js/mermaid
+  '';
+
   packages = with pkgs; [
     mkdocs
     python3Packages.mkdocs-material

--- a/docs/js/.gitignore
+++ b/docs/js/.gitignore
@@ -1,0 +1,1 @@
+mermaid

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,4 +20,6 @@ nav:
 
 plugins:
   - search
-  - mermaid2
+  - mermaid2:
+      # resolve js dependency locally rather than at runtime
+      javascript: ./js/mermaid/mermaid.esm.min.mjs

--- a/packages/docs.nix
+++ b/packages/docs.nix
@@ -1,0 +1,39 @@
+{
+  pkgs,
+  pname,
+  perSystem,
+  ...
+}:
+let
+  inherit (pkgs) lib;
+  fs = lib.fileset;
+in
+pkgs.stdenv.mkDerivation {
+  # pname comes from the name of this file and is passed in by blueprint
+  inherit pname;
+  version = "0.0.1";
+
+  # define the source set, only including necessary files so we avoid unnecessary nix rebuilds
+  src = fs.toSource {
+    root = ../.;
+    fileset = fs.unions [
+      ../docs
+      ../mkdocs.yml
+    ];
+  };
+
+  nativeBuildInputs = with pkgs; [
+    mkdocs
+    python3Packages.mkdocs-material
+    python3Packages.mkdocs-mermaid2-plugin
+  ];
+
+  postUnpack = ''
+    # mkdocs-mermaid2-plugin tries to download mermaidjs at build time
+    # instead we packaged up mermaid in this flake and we symlink it in
+    # mkdocs.yml is configured to look for it there instead
+    ln -s ${perSystem.self.mermaid} ./source/docs/js/mermaid
+  '';
+
+  buildPhase = "mkdocs build -d $out";
+}

--- a/packages/mermaid.nix
+++ b/packages/mermaid.nix
@@ -1,0 +1,39 @@
+{
+  pkgs,
+  pname,
+  version ? "10.9.1",
+  srcHash ? "sha256-JoMmFJd6TkYwn8td/io4Tz3KJKvjE7bmO7Y19urTPaU=",
+  depsHash ? "sha256-M4H0JuEkOD8GvZ6wXIiiZbv6UzJxGA94SPZ22w4qVSA=",
+  ...
+}:
+pkgs.stdenv.mkDerivation (final: {
+  inherit pname version;
+
+  src = pkgs.fetchFromGitHub {
+    owner = "mermaid-js";
+    repo = "mermaid";
+    rev = "v${version}";
+    hash = srcHash;
+  };
+
+  pnpmDeps = pkgs.pnpm.fetchDeps {
+    inherit (final) pname version src;
+    hash = depsHash;
+  };
+
+  nativeBuildInputs = [ pkgs.pnpm.configHook ];
+
+  buildInputs = [ pkgs.nodejs ];
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm build:mermaid
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mv packages/mermaid/dist $out
+    runHook postInstall
+  '';
+})


### PR DESCRIPTION
The `mermaid` plugin for `mkdocs` likes to source `mermaidjs` remotely at run/build time. You can resolve it locally instead, which is what I've configured.

I added a `mermaid` package to this flake which captures `mermaidjs`, and have configured the `devshell` and the `docs` package to symlink it into `./docs/js/mermaid`.

Signed-off-by: Brian McGee <brian@bmcgee.ie>
